### PR TITLE
Revisjon metadatakrav

### DIFF
--- a/content/docs/dps/api/submission/metadata/index.md
+++ b/content/docs/dps/api/submission/metadata/index.md
@@ -42,6 +42,8 @@ Allowed types for describing the resource per media type:
 
 The vocabulary is limited to Norwegian values.
 
+In the requirements for [METS.xml](/nb/docs/dps/sip/1.0/mets/) there is a mandatory attribute named Content category `@TYPE`. Content category specifies the media type on a higher level than this attribute.
+
 > [!TIP]
 > We would like input and suggestions for any missing terms in this vocabulary. It is possible to request the addition of new types if needed.
 
@@ -56,7 +58,7 @@ The vocabulary is limited to Norwegian values.
 
 | Name        | **Identifier**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description | Identifiers (identifier type + ID/value).<br> The `type` and `value` attributes MUST be used to define the identifier type.<br>The `lang` attribute SHOULD be used to specify the language code.|
+| Description | Identifiers (identifier type + ID/value).<br> The `type` and `value` attributes MUST be used to define the identifier type.|
 | Requirement         | MUST                                                                                                                 |
 | Cardinality | 1..n                                                                                                               |
 
@@ -66,8 +68,6 @@ The identifier type MUST be defined.
 The use of the type attribute should be meaningful to the submitter, reflect the metadata catalog or system, and be applied consistently (using a standardized format).
 
 Examples of identifier types may include `URN`, `PID`, `URI` to a record in a catalog or metadata system, `document ID`, `issue ID`, `copy number`, `ISBN`, `ISSN`, `ISMN`, `ISNI`, `DOI`, `record label, etc.
-
-Language code should be specified for the identifier type, if deemed neceessary. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 **Examples:**
 ```json
@@ -79,13 +79,11 @@ Language code should be specified for the identifier type, if deemed neceessary.
     },
     {
       "type": "image-id",
-      "value": "NB_PE_VM_M_05_09_01_036",
-      "lang": "eng"
+      "value": "NB_PE_VM_M_05_09_01_036"
     },
     {
       "type": "call-number",
-      "value": "POEL00003975",
-      "lang": "eng"
+      "value": "POEL00003975"
     }
   ]
 }
@@ -95,7 +93,7 @@ Language code should be specified for the identifier type, if deemed neceessary.
 
 | Name         | **Title**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Name given to the resource. If a title is missing, the recommended practice is to assign the resource a “meaningful” title. <br> The `lang` attribute SHOULD be used to specify the language code. |
+| Description  | Name given to the resource. If a title is missing, the recommended practice is to assign the resource a “meaningful” title. <br> The `lang` attribute SHOULD be used to specify the language of the title. |
 |Requirement        | MUST                                                                                                                 |
 | Cardinality | 1..1                                                                                                               |
 
@@ -107,7 +105,7 @@ Some resources already have predefined titles, such as books, journals, articles
 When a title is missing, the recommended practice is to devise a “meaningful” title for the resource. 
 By meaningful, we mean a title that facilitates recognition and identification of the resource, essentially, a name that makes sense to the submitter.
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The language of the title should be specified according to the [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) standard, using the `lang` attribute is applied.
  
 **Examples:**
 ```json
@@ -151,7 +149,7 @@ To improve searchability by title, it is recommended to add an alternative title
 The alternative titles MUST have a type, to describe what kind of title is submitted.
 The use of the type attribute should be meaningful to the submitter, reflect the metadata catalog or system, and be applied consistently (using a standardized format).
 
-Language code should be specified for the title value (not the type). [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The language of the title should be specified according to the [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) standard, using the `lang` attribute is applied.
 
 **Example:**
 ```json
@@ -170,7 +168,7 @@ Language code should be specified for the title value (not the type). [ISO 639-3
 
 | Name         | **Creator**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Name or entity appearing in a central role (e.g. author, composer, film director, photographer, etc.). <br>The`role` attribute SHOULD be used to define the specific role. <br>The `type` attribute SHOULD be used to indicate the type of entity. Allowed types include: *Person, Korporasjon, Konferanse, Standardtittel*. <br>The `authority` attribute SHOULD be used to specify the authority source. <br>The `lang` attribute SHOULD be used to specify the language code.  |
+| Description  | Name or entity appearing in a central role (e.g. author, composer, film director, photographer, etc.). <br>The`role` attribute SHOULD be used to define the specific role. <br>The `type` attribute SHOULD be used to indicate the type of entity. Allowed types include: `person`, `korporasjon`, `konferanse`, `standardtittel`. <br>The `authority` attribute SHOULD be used to specify the authority source. |
 |Requirement         | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -190,23 +188,21 @@ This is handled in different ways across various metadata catalogs and authority
 The vocabulary is Norwegian. 
 Currently, the following values are allowed to define the type of name or entity though additional types may be added if needed: 
 
-- `Person`
-- `Korporasjon` (organization)
-- `Konferanse` (conferance)
-- `Standardtittel` (uniform title. e.g., treaty, contract)
+- `person`
+- `korporasjon` (organization)
+- `konferanse` (conferance)
+- `standardtittel` (uniform title. e.g., treaty, contract)
 
 The role of the person or organization should be specified. 
 Examples of roles include: 
 author, composer, film director, photographer, creator, etc. 
 
 The use of the role attribute should be meaningful for the data provider, reflect the metadata catalog or system being used, and follow consistent (standardized) formatting.
-  
-Language code should be specified for the role. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 Explanation of *authority* information:
-- **Source:** The name of the authority file from which the value is taken, provided as a plain text string.
-- **Code:** A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
-- **URI:** A persistent link (URI) that points directly to the authority record from which the value is derived.
+- `source`: The name of the authority file from which the value is taken, provided as a plain text string.
+- `code`: A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
+- `URI`: A persistent link (URI) that points directly to the authority record from which the value is derived.
 
 
 **Examples:**
@@ -217,7 +213,6 @@ Explanation of *authority* information:
       "name": "Marek, Václav (1908-1994)",
       "type": "Person",
       "role": "Photographer",
-      "lang": "eng",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "90169632",
@@ -234,7 +229,6 @@ Explanation of *authority* information:
       "name": "Shakespeare, William (1564-1616)",
       "type": "Person",
       "role": "author",
-      "lang": "eng",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "9016555",
@@ -249,17 +243,41 @@ Explanation of *authority* information:
 
 | Name         | **Contributor**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Names appearing in a central role (e.g., illustrator, photographer, co-author). <br>The `role` attribute SHOULD be used to specify the person's or organization's role. <br>The `type` attribute SHOULD be used to indicate the type of authority. Allowed values include: *Person, Korporasjon, Konferanse, Standardtittel* <br>The `lang` attribute SHOULD be used to define the language code.|
+| Description  | Names appearing in a central role (e.g., illustrator, photographer, co-author). <br>The `role` attribute SHOULD be used to specify the person's or organization's role. <br>The `type` attribute SHOULD be used to indicate the type of authority. Allowed types include: `person`, `korporasjon`, `konferanse`, `standardtittel`. <br>The `authority` attribute SHOULD be used to specify the authority source. |
 |Requirement          | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
 **Guidelines for Use:**
-
-The rules for filling in the Contributor field are the same as for the Creator field. 
-Examples of contributor roles may include: contributor, depicted person, illustrator, model, editor, designer, etc.
   
-Language code should be specified for the role. 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The use of an authority register is recommended whenever one is available, both for personal names and corporate entities. 
+The specific authority register used must be identified. 
+An example of such a register is the  [Shared Authority Register for Persons and Corporate Bodies](https://bibliotekutvikling.no/kunnskapsorganisering/vokabularer-utkast/felles-autoritetsregister-for-personer-og-korporasjoner/).
+
+The contributor should also be identified using their full name (first name, last name/corporation). 
+Birth and death years may be included in parentheses after the name. 
+Examples: 
+*Nesbø, Jo (1960– )*, *Shakespeare, William (1564–1616)*. 
+
+It should be specified whether the name refers to a person or a corporation. 
+This is handled in different ways across various metadata catalogs and authority registers. 
+The vocabulary is Norwegian. 
+Currently, the following values are allowed to define the type of name or entity though additional types may be added if needed: 
+
+- `person`
+- `korporasjon` (organization)
+- `konferanse` (conferance)
+- `standardtittel` (uniform title. e.g., treaty, contract)
+
+The role of the person or organization should be specified. 
+Examples of roles include: 
+contributor, depicted person, illustrator, model, editor, designer, etc.
+
+The use of the role attribute should be meaningful for the data provider, reflect the metadata catalog or system being used, and follow consistent (standardized) formatting.
+
+Explanation of *authority* information:
+- `source`: The name of the authority file from which the value is taken, provided as a plain text string.
+- `code`: A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
+- `URI`: A persistent link (URI) that points directly to the authority record from which the value is derived.
 
 
 **Examples:**
@@ -269,13 +287,11 @@ Language code should be specified for the role.
     {
       "role": "depicted",
       "type": "Person",
-      "name": "Nordmann, Ola",
-      "lang": "eng"
+      "name": "Nordmann, Ola"
     },
     {
       "role": "depicted",
-      "name": "Nordmann, Kari",
-      "lang": "eng"
+      "name": "Nordmann, Kari"
     }
   ]
 }
@@ -288,7 +304,6 @@ Language code should be specified for the role.
       "role": "illustrator",
       "type": "Person",
       "name": "Solberg, Erna",
-      "lang": "eng",
       "authority": {
         "source": "Kulturnav",
         "code": "e762d909-5cce-4d2b-892b-258272514fde",
@@ -303,7 +318,7 @@ Language code should be specified for the role.
 
 | Name         | **Publisher**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Names appearing in a central role (the organization or entity that has published the resource). <br> The `type` attribute SHOULD be used to define the type of authority. Allowed types include: *Person, Korporasjon, Konferanse, Standardtittel*<br>The `lang` attribute SHOULD be used to specify the language code. |
+| Description  | Names appearing in a central role (the organization or entity that has published the resource). <br> The `type` attribute SHOULD be used to define the type of authority. Allowed types include: `person`, `korporasjon`, `konferanse`, `standardtittel`. <br>The `authority` attribute SHOULD be used to specify the authority source. |
 | Requirement       | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -322,13 +337,11 @@ When using an authority register, the publisher’s full name should also be pro
 The place and/or year of publication can be added in parentheses after the name. 
 Example: 
 National Library (Oslo, 1984).
-  
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 Explanation of *authority* information:
-- **Source:** The name of the authority file from which the value is taken, provided as a plain text string.
-- **Code:** A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
-- **URI:** A persistent link (URI) that points directly to the authority record from which the value is derived.
+- `source`: The name of the authority file from which the value is taken, provided as a plain text string.
+- `code`: A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
+- `URI`: A persistent link (URI) that points directly to the authority record from which the value is derived.
 
 **Example:**
 ```json
@@ -337,7 +350,6 @@ Explanation of *authority* information:
     {
       "name": "National library of Norway (Oslo, 1984)",
       "type": "Organization",
-      "lang": "eng",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "90362181",
@@ -352,7 +364,7 @@ Explanation of *authority* information:
 
 | Name         | **Spatial**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Names of relevant geographic locations (place names). These may refer to geographic locations such as countries, regions or cities that are significant to the resource. <br> The `type` attribute SHOULD be used to specify what type of place is being referred to.<br> The `lang` attribute SHOULD be used to indicate the language code. |
+| Description  | Names of relevant geographic locations (place names). These may refer to geographic locations such as countries, regions or cities that are significant to the resource. <br> The `type` attribute SHOULD be used to specify what type of place is being referred to.<br>The `authority` attribute SHOULD be used to specify the authority source. |
 | Requirement        | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -368,15 +380,12 @@ When using authority registries to specify spatial information, the full form of
 If no registry is used, the location should preferably be written in the following format: 
 country; region/county; municipality; place; street.
  
-
 Coordinates may be provided using latitude and longitude. 
 The format should be as follows: 
 `latitude`=61.85401 `longitude`=9.80856.
 
 Examples of `type` might include place of publication, recording location, setting, place of printing, place of birth, etc. 
-The use of the type attribute should be meaningful for the data provider, reflect the metadata catalog or system, and follow a consistent and standardized format.
-
-Language code should be specified for the type. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The use of the `type` attribute should be meaningful for the data provider, reflect the metadata catalog or system, and follow a consistent and standardized format.
 
 Explanation of *authority* information:
 - `source`: The name of the authority file from which the value is taken, provided as a plain text string.
@@ -390,7 +399,6 @@ Explanation of *authority* information:
     {
       "name": "Norway (NO);Innlandet;Stor-Elvdal;Rondane gjestegård",
       "type": "Depicted location",
-      "lang": "eng",
       "authority": {
         "source": "Kulturnav",
         "code": "1031636c-0717-4d12-8895-fb88a7d4e952",
@@ -411,7 +419,7 @@ Explanation of *authority* information:
 
 | Name         | **Date**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Relevant dates for the resource (such as publication, copyright, creation, digitization date, etc., including the type of date.). <br> The `type` attribute MUST be used to specify what kind of date it is reffered to. <br> The `lang` attribute SHOULD be used to indicate the language code.   |
+| Description  | Relevant dates for the resource (such as publication, copyright, creation, digitization date, etc., including the type of date.). <br> The `type` attribute MUST be used to specify what kind of date it is reffered to. |
 | Requirement        | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -422,27 +430,21 @@ The type of date and the corresponding year or value must be specified.
 
 The use of the type attribute should be meaningful for the data provider, reflect the metadata catalog or system, and be applied consistently with a standardized format.
 
-Language code should be specified for type. 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
-
 **Examples:**
 ```json
 {
   "date": [
     {
       "type": "Content date",
-      "value": "1938",
-      "lang": "eng"
+      "value": "1938"
     },
     {
       "type": "Digitized",
-      "value": "2022-03-05T14:28:12+02:00",
-      "lang": "eng"
+      "value": "2022-03-05T14:28:12+02:00"
     },
     {
       "type": "Published",
-      "value": "2022-03-12",
-      "lang": "eng"
+      "value": "2022-03-12"
     }
   ]
 }
@@ -491,7 +493,7 @@ The use of the `type` attribute should be meaningful for the data provider, refl
 
 | Name        | **Relation**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description | A related resource in which the described resource is physically or logically included (e.g., title of the parent or related work, collection, series, or part).<br>Attributes for `title` + `type` OR `id` + `type` MUST be used. <br> The`URI` attribute SHOULD be used.<br> The `lang` attribute SHOULD be used to specify the language code.   |
+| Description | A related resource in which the described resource is physically or logically included (e.g., title of the parent or related work, collection, series, or part).<br>Attributes for `title` + `type` OR `id` + `type` MUST be used. <br> The`URI` attribute SHOULD be used.<br> The `lang` attribute SHOULD be used to specify the language of the related resource's title.   |
 | Requirement        | SHOULD                                                                                                                |
 | Cardinality | 0..n                                                                                                               |
 
@@ -563,7 +565,27 @@ The language of the provenance value must be provided using the `lang` attribute
 {
   "provenance": [
     {
-      "value": "The collection was donated to the National Library by Václav Marek on May 12, 1979.",
+      "value": "The image is part of a digital collection that was donated to the National Library of Norway by Ola Nordmann on 2025-01-01.",
+      "lang": "eng"
+    }
+  ]
+}
+```
+```json
+{
+  "provenance": [
+    {
+      "value": "This digital object was previously part of the collection of Museum X between 1999 and 2002, before being transferred to Museum Y. Museum Y deposited the object with the National Library of Norway in 2025.",
+      "lang": "eng"
+    }
+  ]
+}
+```
+```json
+{
+  "provenance": [
+    {
+      "value": "Digitization was carried out internally at the National Library of Norway between 2022 and 2024. The project was initiated and completed after it was discovered that the film was a lost German feature film, with no other known copies internationally. As part of the digital work, the original projection print (ID-12345) was scanned in 2022. The aim of the project was to digitally safeguard the film with its original colour characteristics.",
       "lang": "eng"
     }
   ]
@@ -574,7 +596,7 @@ The language of the provenance value must be provided using the `lang` attribute
 
 | Name         | **Subject**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Subject terms related to the resource.<br> The `lang` attribute SHOULD be used to specify the language code.   |
+| Description  | Subject terms related to the resource.<br>The `authority` attribute SHOULD be used to specify the authority source.  |
 | Requirement        | MAY                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -588,12 +610,10 @@ Dewey Decimal Classification (DDC) values are valid.
 References to authority registers may be used where applicable. 
 When using authority registers, subject terms must also be written out in full.
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
-
 Explanation of *authority* information:
-- **Source:** The name of the authority file from which the value is taken, provided as a plain text string.
-- **Code:** A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
-- **URI:** A persistent link (URI) that points directly to the authority record from which the value is derived.
+- `source`: The name of the authority file from which the value is taken, provided as a plain text string.
+- `code`: A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
+- `URI`: A persistent link (URI) that points directly to the authority record from which the value is derived.
 
 **Examples:**
 ```json
@@ -601,15 +621,12 @@ Explanation of *authority* information:
   "subject": [
     {
       "value": "rondane",
-      "lang": "nor"
     },
     {
       "value": "fishingtrip",
-      "lang": "eng"
     },
     {
-      "value": "nature",
-      "lang": "eng"
+      "value": "nature"
     }
   ]
 }
@@ -620,7 +637,6 @@ Explanation of *authority* information:
   "subject": [
     {
       "value": "natur",
-      "lang": "nor",
       "authority": {
         "source": "Kulturnav",
         "code": "1031536c-0717-4d12-8895-fb88a7d4e952",
@@ -641,7 +657,7 @@ Explanation of *authority* information:
 
 **Guidelines for use:** 
 
-Language code should be specified. 
+Language code must be specified. 
 [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 **Example:**
@@ -655,9 +671,8 @@ Language code should be specified.
   ]
 }
 ```
-<br> 
 
-**Example containing all the metadata elements:**
+## Example containing all the metadata elements
 
 ```json
 {

--- a/content/docs/dps/api/submission/metadata/index.md
+++ b/content/docs/dps/api/submission/metadata/index.md
@@ -67,7 +67,7 @@ In the requirements for [METS.xml](/nb/docs/dps/sip/1.0/mets/) there is a mandat
 The identifier type MUST be defined. 
 The use of the type attribute should be meaningful to the submitter, reflect the metadata catalog or system, and be applied consistently (using a standardized format).
 
-Examples of identifier types may include `URN`, `PID`, `URI` to a record in a catalog or metadata system, `document ID`, `issue ID`, `copy number`, `ISBN`, `ISSN`, `ISMN`, `ISNI`, `DOI`, `record label, etc.
+Examples of identifier types may include URN, PID, URI to a record in a catalog or metadata system, document ID, issue ID, copy number, ISBN, ISSN, ISMN, ISNI, DOI, record label, etc.
 
 **Examples:**
 ```json

--- a/content/docs/dps/api/submission/metadata/index.md
+++ b/content/docs/dps/api/submission/metadata/index.md
@@ -27,7 +27,7 @@ Most metadata elements are optional, but it is strongly recommended to provide a
 
 | Name         | **Type**                                                                     |
 |:--------------|:------------------------------------------------------------------------------|
-| Description  | Type of resource/media type. The National Library uses its own controlled vocabulary for allowed media types. <br>The `lang` attribute SHOULD be used to specify the language code. |
+| Description  | Form/genre of the resource. The National Library uses its own Norwegian controlled vocabulary for allowed types. |
 | Requirement        | MUST                                                                           |
 | Cardinality | 1..1                                                                         | 
 
@@ -35,23 +35,20 @@ Most metadata elements are optional, but it is strongly recommended to provide a
 
 Allowed types for describing the resource per media type: 
 
-- **Text:** `Book`, `Newspaper`, `Journal`, `Article`, `Pamphlet`, `Letter`, `Email`, `Manuscript`, `Music Manuscript`, `Sheet Music`, `Program Report`, `Program Statistics`. 
-- **Images:** `Image`, `Map`, `Poster`, `Postcard`, `Reference Material`.
-- **Audio:** `Audiobook`, `Music`, `Radio`.
-- **Moving images:** `Film`, `Television`.
+- **Text:** `Bok`, `Avis`, `Tidsskrift`, `Artikkel`, `Småtrykk`, `Brev`, `Epost`, `Manuskript`, `Musikkmanuskript`, `Noter`, `Programrapport`, `Programstatistikk`. 
+- **Images:** `Bilde`, `Kart`, `Plakat`, `Postkort`, `Referansemateriale`. 
+- **Audio:** ``Lydbok``, ``Musikk``, ``Radio``.
+- **Moving images:** `Film`, `Fjernsyn`.
+
+The vocabulary is limited to Norwegian values.
 
 > [!TIP]
-> It is possible to request the addition of new media types if needed.
+> We would like input and suggestions for any missing terms in this vocabulary. It is possible to request the addition of new types if needed.
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
-  
 **Example:**
 ```json
 {
-  "type": {
-    "value": "Image",
-    "lang": "eng"
-  }
+  "type": "Bilde"
 }
 ``` 
 
@@ -70,7 +67,7 @@ The use of the type attribute should be meaningful to the submitter, reflect the
 
 Examples of identifier types may include `URN`, `PID`, `URI` to a record in a catalog or metadata system, `document ID`, `issue ID`, `copy number`, `ISBN`, `ISSN`, `ISMN`, `ISNI`, `DOI`, `record label, etc.
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+Language code should be specified for the identifier type, if deemed neceessary. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 **Examples:**
 ```json
@@ -107,8 +104,8 @@ Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:s
 Every package MUST have a title.
 
 Some resources already have predefined titles, such as books, journals, articles, painted works, artistic photographs, etc. 
-When a title is missing, the recommended practice is to assign the resource a “meaningful” title. 
-By meaningful, means a title that facilitates recognition and identification of the resource, essentially, a name that makes sense to the submitter.
+When a title is missing, the recommended practice is to devise a “meaningful” title for the resource. 
+By meaningful, we mean a title that facilitates recognition and identification of the resource, essentially, a name that makes sense to the submitter.
 
 Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
  
@@ -147,17 +144,14 @@ Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:s
 
 **Guidelines for Use:**
 
-To improve searchability by title, it is recommended to add an alternative title when the original title contains numbers and/or special characters, or when numbers are originally written out as words. 
+This attribute allows the resource to be given multiple titles. For example titles on different languages, working titles, etc.
 
-Examples:
-  - `title`: 1-2-3 mathematics = `alternative`: one two three mathematics.
-  - `title`: Kari & Bjarne on a fishingtrip = `alternative`: Kari and Bjarne on a fishingtrip. 
-  - `title`: Tousand mountain peaks  = `alternative`: 1000 mountain peaks.  
+To improve searchability by title, it is recommended to add an alternative title when the original title contains numbers and/or special characters, or when numbers are originally written out as words. 
 
 The alternative titles MUST have a type, to describe what kind of title is submitted.
 The use of the type attribute should be meaningful to the submitter, reflect the metadata catalog or system, and be applied consistently (using a standardized format).
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+Language code should be specified for the title value (not the type). [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 **Example:**
 ```json
@@ -176,7 +170,7 @@ Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:s
 
 | Name         | **Creator**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Name or entity appearing in a central role (e.g. author, composer, film director, photographer, etc.). <br>The`role` attribute SHOULD be used to define the specific role. <br>The `type` attribute SHOULD be used to indicate the type of entity. Allowed types include: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title*. <br>The `authority` attribute SHOULD be used to specify the authority source. <br>The `lang` attribute SHOULD be used to specify the language code.  |
+| Description  | Name or entity appearing in a central role (e.g. author, composer, film director, photographer, etc.). <br>The`role` attribute SHOULD be used to define the specific role. <br>The `type` attribute SHOULD be used to indicate the type of entity. Allowed types include: *Person, Korporasjon, Konferanse, Standardtittel*. <br>The `authority` attribute SHOULD be used to specify the authority source. <br>The `lang` attribute SHOULD be used to specify the language code.  |
 |Requirement         | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -193,16 +187,21 @@ Examples:
 
 It should be specified whether the name refers to a person or a corporation. 
 This is handled in different ways across various metadata catalogs and authority registers. 
-Currently, the following values are allowed to define the type of name or entity, though additional types may be added if needed: 
-`Person`, `Organization`, `Personal Name`, `Corporate Name`, `Meeting Name` (e.g., conference), `Uniform Title` (e.g., treaty, contract).
+The vocabulary is Norwegian. 
+Currently, the following values are allowed to define the type of name or entity though additional types may be added if needed: 
+
+- `Person`
+- `Korporasjon` (organization)
+- `Konferanse` (conferance)
+- `Standardtittel` (uniform title. e.g., treaty, contract)
 
 The role of the person or organization should be specified. 
 Examples of roles include: 
-`author`, `composer`, `film director`, `photographer`, `creator`, etc. 
+author, composer, film director, photographer, creator, etc. 
 
 The use of the role attribute should be meaningful for the data provider, reflect the metadata catalog or system being used, and follow consistent (standardized) formatting.
   
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+Language code should be specified for the role. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 Explanation of *authority* information:
 - **Source:** The name of the authority file from which the value is taken, provided as a plain text string.
@@ -245,20 +244,21 @@ Explanation of *authority* information:
   ]
 }
 ```
+
 ### Contributor
 
 | Name         | **Contributor**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Names appearing in a central role (e.g., illustrator, photographer, co-author). <br>The `role` attribute SHOULD be used to specify the person's or organization's role. <br>The `type` attribute SHOULD be used to indicate the type of authority. Allowed values include: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title.* <br>The `lang` attribute SHOULD be used to define the language code.|
+| Description  | Names appearing in a central role (e.g., illustrator, photographer, co-author). <br>The `role` attribute SHOULD be used to specify the person's or organization's role. <br>The `type` attribute SHOULD be used to indicate the type of authority. Allowed values include: *Person, Korporasjon, Konferanse, Standardtittel* <br>The `lang` attribute SHOULD be used to define the language code.|
 |Requirement          | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
 **Guidelines for Use:**
 
 The rules for filling in the Contributor field are the same as for the Creator field. 
-Examples of contributor roles may include: `contributor`, `depicted person`, `illustrator`, `model`, `editor`, `designer`, etc.
+Examples of contributor roles may include: contributor, depicted person, illustrator, model, editor, designer, etc.
   
-Language code should be specified. 
+Language code should be specified for the role. 
 [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 
@@ -280,6 +280,7 @@ Language code should be specified.
   ]
 }
 ```
+
 ```json
 {
   "contributor": [
@@ -297,11 +298,12 @@ Language code should be specified.
   ]
 }
 ```
+
 ### Publisher
 
 | Name         | **Publisher**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Names appearing in a central role (the organization or entity that has published the resource). <br> The `type` attribute SHOULD be used to define the type of authority. Allowed types include: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title.*<br>The `lang` attribute SHOULD be used to specify the language code. |
+| Description  | Names appearing in a central role (the organization or entity that has published the resource). <br> The `type` attribute SHOULD be used to define the type of authority. Allowed types include: *Person, Korporasjon, Konferanse, Standardtittel*<br>The `lang` attribute SHOULD be used to specify the language code. |
 | Requirement       | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -310,7 +312,12 @@ Language code should be specified.
 It is recommended to use an authority register if one is available. 
 The specific authority register used, as well as the type of authority, MUST be indicated. 
 Allowed types include: 
-`Person`, `Organization`, `Personal Name`, `Corporate Name`, `Meeting Name` (e.g., conference), `Uniform Title` (e.g., treaty, contract).
+
+- `Person`
+- `Korporasjon` (Organization)
+- `Konferanse` (conference)
+- `Standardtittel`  (uniform title  e.g., treaty, contract).
+
 When using an authority register, the publisher’s full name should also be provided. 
 The place and/or year of publication can be added in parentheses after the name. 
 Example: 
@@ -340,6 +347,7 @@ Explanation of *authority* information:
   ]
 }
 ```
+
 ### Spatial
 
 | Name         | **Spatial**                                                                                                     |
@@ -365,15 +373,15 @@ Coordinates may be provided using latitude and longitude.
 The format should be as follows: 
 `latitude`=61.85401 `longitude`=9.80856.
 
-Examples of `type` might include `place of publication`, `recording location`, `setting`, `place of printing`, `place of birth`, etc. 
+Examples of `type` might include place of publication, recording location, setting, place of printing, place of birth, etc. 
 The use of the type attribute should be meaningful for the data provider, reflect the metadata catalog or system, and follow a consistent and standardized format.
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+Language code should be specified for the type. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 Explanation of *authority* information:
-- **Source:** The name of the authority file from which the value is taken, provided as a plain text string.
-- **Code:** A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
-- **URI:** A persistent link (URI) that points directly to the authority record from which the value is derived.
+- `source`: The name of the authority file from which the value is taken, provided as a plain text string.
+- `code`: A unique identifier for the authority entry within the register, typically a numeric or alphanumeric code.
+- `URI`: A persistent link (URI) that points directly to the authority record from which the value is derived.
 
 **Examples:**
 ```json
@@ -398,11 +406,12 @@ Explanation of *authority* information:
   ]
 }
 ```
+
 ### Date
 
 | Name         | **Date**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Relevant dates for the resource (such as publication, copyright, creation, digitization, etc., including the type of date and the corresponding year or value). <br> The `type` attribute MUST be used to specify what kind of date it is reffered to. <br> The `lang` attribute SHOULD be used to indicate the language code.   |
+| Description  | Relevant dates for the resource (such as publication, copyright, creation, digitization date, etc., including the type of date.). <br> The `type` attribute MUST be used to specify what kind of date it is reffered to. <br> The `lang` attribute SHOULD be used to indicate the language code.   |
 | Requirement        | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
@@ -413,7 +422,7 @@ The type of date and the corresponding year or value must be specified.
 
 The use of the type attribute should be meaningful for the data provider, reflect the metadata catalog or system, and be applied consistently with a standardized format.
 
-Language code should be specified. 
+Language code should be specified for type. 
 [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
 
 **Examples:**
@@ -438,17 +447,18 @@ Language code should be specified.
   ]
 }
 ```
+
 ### Language
 
 | Name         | **Language**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Languages relevant to the resource. <br> The `lang` attribute MUST be used to specify the language code. <br> The `type` attribute MUST be used to define what the language represents (e.g., subtitles, spoken language, written language, etc.).   |
+| Description  | Languages used in the resource. The value should confirm to a [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) code.<br> The `type` attribute MUST be used to define what the language represents (e.g., subtitles, spoken language, written language, etc.).   |
 | Requirement        | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
 **Guidelines for Use:**
 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The value should be in the form of a [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) code.
 
 The type of language representation must be indicated. 
 Examples of language types include subtitles, spoken language, written language, etc. 
@@ -461,8 +471,7 @@ The use of the `type` attribute should be meaningful for the data provider, refl
   "language": [
     {
       "type": "subtitle",
-      "value": "english",
-      "lang": "eng"
+      "value": "eng"
     }
   ]
 }
@@ -472,12 +481,12 @@ The use of the `type` attribute should be meaningful for the data provider, refl
   "language": [
     {
       "type": "written language",
-      "value": "french",
-      "lang": "eng"
+      "value": "fre",
     }
   ]
 }
 ```
+
 ### Relation
 
 | Name        | **Relation**                                                                                                     |
@@ -490,7 +499,7 @@ The use of the `type` attribute should be meaningful for the data provider, refl
 
 The use of attributes may vary, but the `type` attribute AND `title` attribute or `id` attribute are always required.
 
-The `title` attribute specifies the title of the related resource. 
+The `title` attribute specifies the title of the related resource. Language of the title should be specified using the `lang` attribute and a code from the [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) standard.
 
 The `type` attribute indicates the nature of the relationship between resources. 
 It is recommended to use terms from Dublin Core (`conformsTo`, `hasFormat`, `hasPart`, `hasVersion`, `isFormatOf`, `isPartOf`, `isReferencedBy`, `isReplacedBy`, `isRequiredBy`, `isVersionOf`, `references`, `replaces`, `requires`).
@@ -500,18 +509,16 @@ An example of using the `id` attribute is to reference a series record, work rec
 
 The `URI` attribute is used to provide a link to the related resource (such as a catalog record or webpage). 
 
-Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
-
 **Examples:**
 ```json
 {
   "relation": [
     {
       "title": "Norway from end to end with Ola and Kari",
+      "lang": "eng",
       "id": "987654321",
       "type": "IsPartOf",
-      "URI": "https://www.nb.no/items/eb57e3c314894b0120cf631104065e74?page",
-      "lang": "eng"
+      "URI": "https://www.nb.no/items/eb57e3c314894b0120cf631104065e74?page"
     }
   ]
 }
@@ -521,8 +528,8 @@ Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:s
   "relation": [
     {
       "title": "Chronicles of Narnia",
-      "type": "IsPartOf",
-      "lang": "eng"
+      "lang": "eng",
+      "type": "IsPartOf"
     }
   ]
 }
@@ -543,14 +550,13 @@ Language code should be specified. [ISO 639-3](https://www.iso.org/obp/ui/#iso:s
 
 | Name         | **Provenance**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Description  | Information about any changes that may affect the authenticity, integrity, or interpretation of the resource (e.g., ownership, management, etc.). <br> The `lang` attribute SHOULD be used to spesify the language code.   |
+| Description  | Information about any changes that may affect the authenticity, integrity, or interpretation of the resource (e.g., ownership, management, etc.). <br> The `lang` attribute MUST be used to spesify the language of the attribute.   |
 | Requirement        | SHOULD                                                                                                                 |
 | Cardinality | 0..n                                                                                                               |
 
 **Guidelines for use:**
 
-Language code should be specified. 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) is used as the standard for indicating language when the `lang` attribute is applied.
+The language of the provenance value must be provided using the `lang` attribute according to the [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) standard. 
 
 **Example:**
 ```json
@@ -563,6 +569,7 @@ Language code should be specified.
   ]
 }
 ```
+
 ### Subject
 
 | Name         | **Subject**                                                                                                     |

--- a/content/docs/dps/api/submission/metadata/index.nb.md
+++ b/content/docs/dps/api/submission/metadata/index.nb.md
@@ -65,7 +65,7 @@ I kravene til [METS.xml](/nb/docs/dps/sip/1.0/mets/) har vi et påkrevd attribut
 Det MÅ defineres type identifikator. 
 Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
 
-Eksempler på identifikatortyper kan være `URN`, `PID`, `URI` til post i en katalog/metadatasystem, `dokID`, `hefteID`, `eksemplarnummer`, `ISBN`, `ISSN`, `ISMN`, `ISNI`, `DOI`, `plateetikett` etc. 
+Eksempler på identifikatortyper kan være URN, PID, URI til post i en katalog/metadatasystem, dokID, hefteID, eksemplarnummer, ISBN, ISSN, ISMN, ISNI, DOI, plateetikett etc. 
 
 **Eksempler:**
 ```json

--- a/content/docs/dps/api/submission/metadata/index.nb.md
+++ b/content/docs/dps/api/submission/metadata/index.nb.md
@@ -40,7 +40,7 @@ Tillatte typer for å beskrive ressursen sortert på medietype:
 
 Vokabularet har kun norske verdier.
 
-I kravene til [METS.xml](/nb/docs/dps/sip/1.0/mets/) har vi et påkrevd felt som heter Content category `@TYPE`. Content category angir medietype på overordnet nivå.
+I kravene til [METS.xml](/nb/docs/dps/sip/1.0/mets/) har vi et påkrevd attributt som heter Content category `@TYPE`. Content category angir medietype på overordnet nivå.
  
 > [!TIP]
 > Vi ønsker innspill på dette vokabularet. Det vil være muligheter for å få lagt til flere gyldige typer ved behov.
@@ -91,7 +91,7 @@ Eksempler på identifikatortyper kan være `URN`, `PID`, `URI` til post i en kat
 
 | Navn         | **Title**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Navn gitt til ressursen. Der tittel mangler er anbefalt praksis å gi ressursen en “meningsbærende” tittel. <br> Attributt `lang` BØR brukes for å definere språkkode. |
+| Beskrivelse  | Navn gitt til ressursen. Der tittel mangler er anbefalt praksis å gi ressursen en “meningsbærende” tittel. <br> Attributt `lang` BØR brukes for å definere tittelens språk. |
 | Krav         | MÅ                                                                                                                 |
 | Kardinalitet | 1..1                                                                                                               |
 
@@ -103,7 +103,7 @@ En del ressurser har allerede en forhåndsdefinert tittel, som bøker, tidsskrif
 Der tittel mangler er anbefalt praksis å konstruere en meningsbærerende tittel for ressursen. 
 Med meningsbærende menes noe som gir mening for gjenkjennelse og identifikasjon av ressursen (navn som gir mening for avleverer). 
 
-Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en). 
+Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) med `lang`-attributten. 
 
 **Eksempler:**
 ```json
@@ -147,7 +147,7 @@ For å bedre muligheter for søk på tittel anbefales det å legge til alternati
 Den alternative tittelen MÅ ha en type, for å beskrive hva slags type tittel som oppgis. 
 Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform).
 
-Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en). 
+Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) med `lang`-attributten.
 
 **Eksempel:**
 ```json
@@ -166,7 +166,7 @@ Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www
 
 | Navn         | **Creator**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Navn/korporasjon som opptrer i sentral rolle (forfatter, komponist, filmregissør, fotograf, etc.). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type. Tillatte typer: `Person`, `Korporasjon`, `Konferanse`, `Standardtittel. <br>Attributt `authority` BØR brukes for å angi autoritet.  |
+| Beskrivelse  | Navn/korporasjon som opptrer i sentral rolle (forfatter, komponist, filmregissør, fotograf, etc.). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type. Tillatte typer: `person`, `korporasjon`, `konferanse`, `standardtittel`. <br>Attributt `authority` BØR brukes for å angi autoritet.  |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -185,10 +185,10 @@ Det bør oppgis om det er snakk om personnavn eller korporasjon.
 Dette er løst på ulike måter i ulike metadatakataloger og autoritetsregistre.
 Foreløpig er disse verdiene tillat for angivelse av navn/korporasjon (type), men det er mulig å få lagt til flere typer ved behov: 
 
-- `Person`
-- `Korporasjon`
-- `Konferanse`
-- `Standardtittel`  (traktat, kontrakt).  
+- `person`
+- `korporasjon`
+- `konferanse`
+- `standardtittel`  (traktat, kontrakt).  
 
 Det bør oppgis hvilken rolle (role) navn/korporasjoner har. 
 Eksempler på roller er: 
@@ -484,7 +484,7 @@ Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalo
 
 | Navn         | **Relation**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | En relatert ressurs der den beskrevne ressursen er fysisk eller logisk inkludert (tittel på overordnet verk, samling, serie, del).<br>Det MÅ brukes attributter for `title` + `type` ELLER `id` + `type`.<br>Attributt `URI` BØR brukes. <br> Attributt `lang` BØR brukes for å definere språkkode.   |
+| Beskrivelse  | En relatert ressurs der den beskrevne ressursen er fysisk eller logisk inkludert (tittel på overordnet verk, samling, serie, del).<br>Det MÅ brukes attributter for `title` + `type` ELLER `id` + `type`.<br>Attributt `URI` BØR brukes. <br> Attributt `lang` BØR brukes for å definere språket på tittelen til den relaterte ressursen.   |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -549,14 +549,14 @@ Attributt `URI` brukes for å angi lenke til relatert ressurs (katalogpost, nett
 
 **Retningslinjer for bruk:**
 
-Språkkode må angis med `lang`-attributtet for verdien i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en).
+Språket brukt til å beskrive provenance bør oppgis med `lang`-attributtet for verdien i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en).
 
 **Eksempel:**
 ```json
 {
   "provenance": [
     {
-      "value": "Bildet er del av en digital samling, som ble donert til Nasjonalbiblioteket av Ola Nordmann 2025-01-01. Se avtale 12345.",
+      "value": "Bildet er del av en digital samling, som ble donert til Nasjonalbiblioteket av Ola Nordmann 2025-01-01.",
       "lang": "nor"
     }
   ]
@@ -576,7 +576,7 @@ Språkkode må angis med `lang`-attributtet for verdien i henhold til [ISO 639-3
 {
   "provenance": [
     {
-      "value": "Digital bevaring gjort internt ved Nasjonalbiblioteket i 2022-24. Prosjektet ble startet og ferdigstilt etter det ble oppdaget at filmen var en tapt tysk spillefilm, uten andre kjente kopier. I det digitale arbeidet ble den originale visningskopien (ID-X) skannet i 2022. Prosjektet hadde som mål å digitalt sikre filmen, med dens originale uttrykk. ",
+      "value": "Digitisering gjort internt ved Nasjonalbiblioteket i 2022-24. Prosjektet ble startet og ferdigstilt etter det ble oppdaget at filmen var en tapt tysk spillefilm, uten andre kjente kopier. I det digitale arbeidet ble den originale visningskopien (ID-12345) skannet i 2022. Prosjektet hadde som mål å digitalt sikre filmen, med dens originale fargeuttrykk. ",
       "lang": "nor"
     }
   ]
@@ -617,7 +617,7 @@ Forklaring til bruk av *authority*-informasjon:
       "value": "fisketur",
     },
     {
-      "value": "natur",
+      "value": "natur"
     }
   ]
 }

--- a/content/docs/dps/api/submission/metadata/index.nb.md
+++ b/content/docs/dps/api/submission/metadata/index.nb.md
@@ -25,39 +25,38 @@ Dette gir bedre søkbarhet og forståelse av ressursene – også i et langtidsp
 
 | Navn         | **Type**                                                                     |
 |:-------------|:-----------------------------------------------------------------------------|
-| Beskrivelse  | Type ressurs/medietype. NB bruker et eget vokabular for tillatte medietyper.<br>Attributt `lang` BØR brukes for å definere språkkode. |
+| Beskrivelse  | Form/sjanger på ressursen. NB bruker et eget vokabular for tillatte typer.   |
 | Krav         | MÅ                                                                           |
 | Kardinalitet | 1..1                                                                         | 
 
 **Retningslinjer for bruk:**
 
-Tillatte typer for å beskrive ressursen per medietype: 
+Tillatte typer for å beskrive ressursen sortert på medietype: 
 
 - **Tekst:** `Bok`, `Avis`, `Tidsskrift`, `Artikkel`, `Småtrykk`, `Brev`, `Epost`, `Manuskript`, `Musikkmanuskript`, `Noter`, `Programrapport`, `Programstatistikk`. 
 - **Bilder:** `Bilde`, `Kart`, `Plakat`, `Postkort`, `Referansemateriale`. 
 - **Lyd:** ``Lydbok``, ``Musikk``, ``Radio``.
 - **Levende bilder:** `Film`, `Fjernsyn`.
 
+Vokabularet har kun norske verdier.
+
+I kravene til [METS.xml](/nb/docs/dps/sip/1.0/mets/) har vi et påkrevd felt som heter Content category `@TYPE`. Content category angir medietype på overordnet nivå.
  
 > [!TIP]
-> Det vil være muligheter for å få lagt til flere gyldige typer ved behov.
-
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
+> Vi ønsker innspill på dette vokabularet. Det vil være muligheter for å få lagt til flere gyldige typer ved behov.
   
 **Eksempel:**
 ```json
 {
-  "type": {
-    "value": "Bilde",
-    "lang": "nor"
-  }
+  "type": "Bilde"
 }
 ``` 
+
 ### Identifier
 
 | Navn         | **Identifier**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Identifikatorer (type ID + ID/verdi). <br>Attributt `type` og `value` MÅ brukes for å definere type identifikator.<br>Attributt `lang` BØR brukes for å definere språkkode.|
+| Beskrivelse  | Identifikatorer (type ID + ID/verdi). <br>Attributt `type` og `value` MÅ brukes for å definere type identifikator.|
 | Krav         | MÅ                                                                                                                 |
 | Kardinalitet | 1..n                                                                                                               |
 
@@ -67,8 +66,6 @@ Det MÅ defineres type identifikator.
 Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
 
 Eksempler på identifikatortyper kan være `URN`, `PID`, `URI` til post i en katalog/metadatasystem, `dokID`, `hefteID`, `eksemplarnummer`, `ISBN`, `ISSN`, `ISMN`, `ISNI`, `DOI`, `plateetikett` etc. 
-
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
 
 **Eksempler:**
 ```json
@@ -80,17 +77,16 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
     },
     {
       "type": "bilde-id",
-      "value": "NB_PE_VM_M_05_09_01_036",
-      "lang": "nor"
+      "value": "NB_PE_VM_M_05_09_01_036"
     },
     {
       "type": "hyllesignatur",
-      "value": "POEL00003975",
-      "lang": "nor"
+      "value": "POEL00003975"
     }
   ]
 }
 ```
+
 ### Title
 
 | Navn         | **Title**                                                                                                     |
@@ -104,10 +100,10 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
 Alle pakker MÅ ha en tittel.
 
 En del ressurser har allerede en forhåndsdefinert tittel, som bøker, tidsskrift, artikler, malte verk, kunstfoto osv. 
-Der tittel mangler er anbefalt praksis å gi ressursen en “meningsbærende” tittel. 
+Der tittel mangler er anbefalt praksis å konstruere en meningsbærerende tittel for ressursen. 
 Med meningsbærende menes noe som gir mening for gjenkjennelse og identifikasjon av ressursen (navn som gir mening for avleverer). 
 
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes. 
+Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en). 
 
 **Eksempler:**
 ```json
@@ -133,6 +129,7 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
   }
 }
 ```
+
 ### Alternative
 
 | Navn         | **Alternative**                                                                                                     |
@@ -143,17 +140,14 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
 
 **Retningslinjer for bruk:**
 
+Denne attributten gir mulighet for å oppgi flere titler, for eksempel titler på andre språk, arbeidstitler, etc.
+
 For å bedre muligheter for søk på tittel anbefales det å legge til alternativ tittel der tittelen inneholder tall og/eller spesialtegn, eller der tall opprinnelig er skrevet som tekst. 
 
-Eksempler:
-- `title`: 1-2-3 Matematikk = `alternative`: en to tre matematikk.
-- `title`: Kari & Bjarne på fisketur = `alternative`: Kari og Bjarne på fisketur. 
-- `title`: Tusen fjelltopper = `alternative`: 1000 fjelltopper.  
-
-Den alterantive tittelen MÅ ha en type, for å beskrive hva slags type tittel som oppgis. 
+Den alternative tittelen MÅ ha en type, for å beskrive hva slags type tittel som oppgis. 
 Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform).
 
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes. 
+Tittelens språk bør angis med språkkode i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en). 
 
 **Eksempel:**
 ```json
@@ -167,11 +161,12 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
   ]
 }
 ```
+
 ### Creator
 
 | Navn         | **Creator**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Navn/korporasjon som opptrer i sentral rolle (forfatter, komponist, filmregissør, fotograf, ukjent etc.). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type. Tillatte typer: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title*. <br>Attributt `authority` BØR brukes for å angi autoritet. <br>Attributt `lang` BØR brukes for å definere språkkode.  |
+| Beskrivelse  | Navn/korporasjon som opptrer i sentral rolle (forfatter, komponist, filmregissør, fotograf, etc.). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type. Tillatte typer: `Person`, `Korporasjon`, `Konferanse`, `Standardtittel. <br>Attributt `authority` BØR brukes for å angi autoritet.  |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -189,20 +184,22 @@ Eksempler:
 Det bør oppgis om det er snakk om personnavn eller korporasjon. 
 Dette er løst på ulike måter i ulike metadatakataloger og autoritetsregistre.
 Foreløpig er disse verdiene tillat for angivelse av navn/korporasjon (type), men det er mulig å få lagt til flere typer ved behov: 
-`Person`, `Organization`, `Personal Name`, `Corporate Name`, `Meeting Name` (konferanse), `Uniform Title`  (traktat, kontrakt).  
+
+- `Person`
+- `Korporasjon`
+- `Konferanse`
+- `Standardtittel`  (traktat, kontrakt).  
 
 Det bør oppgis hvilken rolle (role) navn/korporasjoner har. 
 Eksempler på roller er: 
-`forfatter`, `komponist`, `filmregissør`, `fotograf`, `skaper etc. 
+forfatter, komponist, filmregissør, fotograf, skaper etc. 
 
 Bruk av role-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
 
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
-
 Forklaring til bruk av *authority*-informasjon: 
-- **Source:** Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
-- **Code:** En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
-- **URI:** En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
+- `source`: Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
+- `code`: En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
+- `URI`: En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
 
 **Eksempler:**
 ```json
@@ -212,7 +209,6 @@ Forklaring til bruk av *authority*-informasjon:
       "name": "Marek, Václav (1908-1994)",
       "type": "Person",
       "role": "fotograf",
-      "lang": "nor",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "90169632",
@@ -229,7 +225,6 @@ Forklaring til bruk av *authority*-informasjon:
       "name": "Shakespeare, William (1564-1616)",
       "type": "Person",
       "role": "forfatter",
-      "lang": "nor",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "9016555",
@@ -239,20 +234,44 @@ Forklaring til bruk av *authority*-informasjon:
   ]
 }
 ```
+
 ### Contributor
 
 | Navn         | **Contributor**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Navn som opptrer i sentral rolle (illustratør, fotograf, medforfatter). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type autoritet. Tillatte typer: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title.* <br>Attributt `lang` BØR brukes for å definere språkkode.|
+| Beskrivelse  | Navn som opptrer i sentral rolle (illustratør, fotograf, medforfatter). <br>Attributt `role` BØR brukes for å definere rolle. <br>Attributt `type` BØR brukes for å angi type autoritet. Tillatte typer: `Person`, `Korporasjon`, `Konferanse`, `Standardtittel`.<br>Attributt `authority` BØR brukes for å angi autoritet. |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
 **Retningslinjer for bruk:**
 
-Regler for utfylling av Contributor-feltet er de samme som Creator-feltet. 
-Eksempler på roller for Contributor kan være: `bidragsyter`, `avbildet`, `illustratør`, `modell`, `redaktør`, `designer` etc.  
+Det anbefales å referere til autoritetsregistre når relevante slik eksisterer, både for personnavn og korporasjoner. 
+Det må oppgis hvilket autoritetsregister som er benyttet. 
+Et eksempel på autoritetsregister er [Felles autoritetsregister for personer og korporasjoner](https://bibliotekutvikling.no/kunnskapsorganisering/vokabularer-utkast/felles-autoritetsregister-for-personer-og-korporasjoner/).
 
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
+Contributor identiseres i tillegg ved å skrives ut i sin fulle form (navn, etternavn/korporasjon). 
+Fødselsår - dødsår kan legges til bak navnet i parentes. 
+Eksempler: 
+*Nesbø, Jo (1960-  ), Shakespeare, William (1564-1616)*. 
+
+Det bør oppgis om det er snakk om personnavn eller korporasjon. 
+Dette er løst på ulike måter i ulike metadatakataloger og autoritetsregistre.
+Foreløpig er disse verdiene tillat for angivelse av navn/korporasjon (type), men det er mulig å få lagt til flere typer ved behov: 
+
+- `Person`
+- `Korporasjon`
+- `Konferanse`
+- `Standardtittel`  (traktat, kontrakt).  
+
+Det bør oppgis hvilken rolle (role) navn/korporasjoner har. 
+Eksempler på roller er: bidragsyter, avbildet, illustratør, modell, redaktør, designer etc.  
+
+Bruk av role-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
+
+Forklaring til bruk av *authority*-informasjon: 
+- `source`: Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
+- `code`: En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
+- `URI`: En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
 
 
 **Eksempler:**
@@ -263,16 +282,15 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
       "role": "avbildet",
       "type": "Person",
       "name": "Nordmann, Ola",
-      "lang": "nor"
     },
     {
       "role": "avbildet",
       "name": "Nordmann, Kari",
-      "lang": "nor"
     }
   ]
 }
 ```
+
 ```json
 {
   "contributor": [
@@ -280,7 +298,6 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
       "role": "illustratør",
       "type": "Person",
       "name": "Solberg, Erna",
-      "lang": "nor",
       "authority": {
         "source": "Kulturnav",
         "code": "e762d909-5cce-4d2b-892b-258272514fde",
@@ -290,11 +307,12 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
   ]
 }
 ```
+
 ### Publisher
 
 | Navn         | **Publisher**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Navn som opptrer i sentral rolle (Organisasjonen eller enheten som har publisert ressursen). <br> Attributt `type` BØR brukes for å definer type autoritet. Tillatte typer: *Person, Organization, Personal Name, Corporate Name, Meeting Name, Uniform Title.*<br>Attributt `lang` BØR brukes for å definere språkkode. |
+| Beskrivelse  | Navn som opptrer i sentral rolle (Organisasjonen eller enheten som har publisert ressursen). <br> Attributt `type` BØR brukes for å definer type autoritet. Tillatte typer: `Person`, `Korporasjon`, `Konferanse`, `Standardtittel`<br>Attributt `authority` BØR brukes for å angi autoritet.  |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -302,18 +320,21 @@ Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-
 
 Det anbefales å bruke autoritetsregister hvis det finnes. 
 Det MÅ oppgis hvilket autoritetsregister som er benyttet, og hvilken type autoritet det er (type): 
-`Person`, `Organization`, `Personal Name`, `Corporate Name`, `Meeting Name` (konferanse), `Uniform Title`  (traktat, kontrakt). 
+
+- `Person`
+- `Korporasjon`
+- `Konferanse`
+- `Standardtittel`  (traktat, kontrakt).  
+
 Ved bruk av autoritetsregister bør utgiver i tillegg skrives ut i sin fulle form.
 Sted og/eller år for utgivelse kan legges til i parantes bak navnet. 
 Eksempel: 
 Nasjonalbiblioteket (Oslo, 1984). 
-  
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
 
-Forklaring til bruk av *authority*-informasjon:
-- **Source:** Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
-- **Code:** En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
-- **URI:** En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
+Forklaring til bruk av *authority*-informasjon: 
+- `source`: Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
+- `code`: En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
+- `URI`: En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
 
 **Eksempel:**
 ```json
@@ -322,7 +343,6 @@ Forklaring til bruk av *authority*-informasjon:
     {
       "name": "Nasjonalbiblioteket (Oslo, 1984)",
       "type": "Organization",
-      "lang": "nor",
       "authority": {
         "source": "Felles autoritetsregister (BARE)",
         "code": "90362181",
@@ -332,11 +352,12 @@ Forklaring til bruk av *authority*-informasjon:
   ]
 }
 ```
+
 ### Spatial
 
 | Navn         | **Spatial**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Relevante stedsnavn for ressursen. Kan referere til geografiske steder som land, regioner og byer som har betydning for ressursen. <br> Det BØR angis `type` for hvilket sted som oppgis.<br>Attributt `lang` BØR brukes for å definere språkkode.  |
+| Beskrivelse  | Relevante stedsnavn for ressursen. Kan referere til geografiske steder som land, regioner og byer som har betydning for ressursen. <br> Det BØR angis `type` for hvilket sted som oppgis.<br>Attributt `authority` BØR brukes for å angi autoritet.  |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -354,15 +375,13 @@ Det er mulig å oppgi koordinater i form av lengde- og breddegrader.
 Det skal brukes på denne måten: 
 `latitude`=61.85401 `longitude`=9.80856
 
-Eksempler på `type` sted kan være `utgiversted`, `innspillingssted`, `handlingssted`, `trykkested`, `fødested` osv. 
+Eksempler på `type` sted kan være utgiversted, innspillingssted, handlingssted, trykkested, fødested osv. 
 Bruk av `type`-attributt her bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform).  
 
-Språkkode bør angis. [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
-
 Forklaring til bruk av *authority*-informasjon: 
-- **Source:** Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
-- **Code:** En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
-- **URI:** En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
+- `source`: Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
+- `code`: En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
+- `URI`: En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
 
 **Eksempel:**
 ```json
@@ -371,7 +390,6 @@ Forklaring til bruk av *authority*-informasjon:
     {
       "name": "Norge (NO);Innlandet;Stor-Elvdal;Rondane gjestegård",
       "type": "Avbildet sted",
-      "lang": "nor",
       "authority": {
         "source": "Kulturnav",
         "code": "1031636c-0717-4d12-8895-fb88a7d4e952",
@@ -387,11 +405,12 @@ Forklaring til bruk av *authority*-informasjon:
   ]
 }
 ```
+
 ### Date
 
 | Navn         | **Date**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Relevante datoer for ressursen (utgivelse, copyright, opprettelse/digitaliseringsdato etc., type årstall + årstall/verdi).  <br> Attributt `type` MÅ brukes for å definere type dato.<br>Attributt `lang` BØR brukes for å definere språkkode.   |
+| Beskrivelse  | Relevante datoer for ressursen (for eksempel utgivelses-, copyright-, opprettelse-/digitaliseringsdato etc. med type).  <br> Attributt `type` MÅ brukes for å definere type dato.  |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -400,10 +419,7 @@ Forklaring til bruk av *authority*-informasjon:
 Det må angis type årstall + årstall/verdi. 
 [ISO 8601-2](https://www.iso.org/obp/ui/en/#iso:std:iso:8601:-2:ed-1:v1:en) brukes som standard.  
 
-Bruke av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
-
-Språkkode bør angis. 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
+Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform). 
 
 **Eksempler:**
 ```json
@@ -411,33 +427,31 @@ Språkkode bør angis.
   "date": [
     {
       "type": "motivdato",
-      "value": "1938",
-      "lang": "nor"
+      "value": "1938"
     },
     {
       "type": "digitalisert",
-      "value": "2022-03-05T14:28:12+02:00",
-      "lang": "nor"
+      "value": "2022-03-05T14:28:12+02:00"
     },
     {
       "type": "publisert",
-      "value": "2022-03-12",
-      "lang": "nor"
+      "value": "2022-03-12"
     }
   ]
 }
 ```
+
 ### Language
 
 | Navn         | **Language**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Språk som er relevant for ressursen. <br> Attributt `lang` MÅ brukes for å definere språkkode. <br> Attributt `type` MÅ brukes for å definere hva språket representerer (undertekster, talespråk, skriftspråk etc.).   |
+| Beskrivelse  | Språk som benyttes i ressursen. Verdien skal oppgis i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en). <br>Attributt `type` MÅ brukes for å definere hva språket representerer (undertekster, talespråk, skriftspråk etc.).   |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
 **Retningslinjer for bruk:**
 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
+Verdien skal oppgis i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en).
 
 Det må angis type for hva språket representerer. 
 Eksempler på type som språket representerer kan være undertekster, talespråk, skriftspråk etc.  
@@ -450,8 +464,7 @@ Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalo
   "language": [
     {
       "type": "undertekster",
-      "value": "engelsk",
-      "lang": "nor"
+      "value": "eng"
     }
   ]
 }
@@ -461,12 +474,12 @@ Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalo
   "language": [
     {
       "type": "skriftspråk",
-      "value": "fransk",
-      "lang": "nor"
+      "value": "fre",
     }
   ]
 }
 ```
+
 ### Relation
 
 | Navn         | **Relation**                                                                                                     |
@@ -479,17 +492,15 @@ Bruk av `type`-attributt bør gi mening for avleverer, gjenspeile metadatakatalo
 
 Bruk av attributter kan varieres, men det kreves alltid bruk av `type` OG `title` eller `id`.
 
-Attributt `title` angir tittel på relatert ressurs. 
+Attributt `title` angir tittel på relatert ressurs. Tittelens språk bør angis med med `lang`-attributten i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en).
 
 Attributt `type` angir hvilken type relasjon det er mellom ressurser. 
-Bruk av termer fra Dublin Core anbefales (`conformsTo`, `hasFormat`, `hasPart`, `hasVersion`, `isFormatOf`, `isPartOf`, `isReferencedBy`, `isReplacedBy`, `isRequiredBy`, `isVersionOf`, `references`, `replaces`, `requires`) 
+Bruk av termer fra Dublin Core anbefales (`conformsTo`, `hasFormat`, `hasPart`, `hasVersion`, `isFormatOf`, `isPartOf`, `isReferencedBy`, `isReplacedBy`, `isRequiredBy`, `isVersionOf`, `references`, `replaces`, `requires`) .
 Hvis andre termer brukes bør de gi mening for avleverer, gjenspeile metadatakatalog/system, og bruken bør være konsekvent (standardisert skriveform).
 
 Eksempel på bruk av attributt `id` er henvisning til en seriepost, verkspost, eller andre ressurser i samme i serie/verk.
 
 Attributt `URI` brukes for å angi lenke til relatert ressurs (katalogpost, nettside).  
-
-Språkkode bør angis (lang-attributt). [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
 
 **Eksempler:**
 ```json
@@ -497,10 +508,10 @@ Språkkode bør angis (lang-attributt). [ISO 639-3](https://www.iso.org/obp/ui/#
   "relation": [
     {
       "title": "Norge på langs med Ola og Kari",
+      "lang": "nor",
       "id": "987654321",
       "type": "IsPartOf",
-      "URI": "https://www.nb.no/items/eb57e3c314894b0120cf631104065e74?page",
-      "lang": "nor"
+      "URI": "https://www.nb.no/items/eb57e3c314894b0120cf631104065e74?page"
     }
   ]
 }
@@ -510,8 +521,8 @@ Språkkode bør angis (lang-attributt). [ISO 639-3](https://www.iso.org/obp/ui/#
   "relation": [
     {
       "title": "Chronicles of Narnia",
-      "type": "IsPartOf",
-      "lang": "eng"
+      "lang": "eng",
+      "type": "IsPartOf"
     }
   ]
 }
@@ -532,31 +543,52 @@ Språkkode bør angis (lang-attributt). [ISO 639-3](https://www.iso.org/obp/ui/#
 
 | Navn         | **Provenance**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Informasjon om eventuelle endringer som har betydning for ressursens autentisitet, integritet og tolkning (eierskap, forvaltning etc). <br> Attributt `lang` BØR brukes for å definere språkkode.   |
+| Beskrivelse  | Informasjon om eventuelle endringer som har betydning for ressursens autentisitet, integritet og tolkning (eierskap, forvaltning etc). <br> Attributt `lang` MÅ brukes for å definere språkkode for verdien.   |
 | Krav         | BØR                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
 **Retningslinjer for bruk:**
 
-Språkkode bør angis (lang-attributt). 
-[ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
+Språkkode må angis med `lang`-attributtet for verdien i henhold til [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en).
 
 **Eksempel:**
 ```json
 {
   "provenance": [
     {
-      "value": "Samlingen ble donert til Nasjonalbiblioteket av Václav Marek 1979-05-12",
+      "value": "Bildet er del av en digital samling, som ble donert til Nasjonalbiblioteket av Ola Nordmann 2025-01-01. Se avtale 12345.",
       "lang": "nor"
     }
   ]
 }
 ```
+```json
+{
+  "provenance": [
+    {
+      "value": "Dette digitale objektet var tidligere en del av samlinga til Museum X mellom 1999 og 2002, før den ble overført til Museum Y. Museum Y deponerte objektet til Nasjonalbiblioteket i 2025",
+      "lang": "nor"
+    }
+  ]
+}
+```
+```json
+{
+  "provenance": [
+    {
+      "value": "Digital bevaring gjort internt ved Nasjonalbiblioteket i 2022-24. Prosjektet ble startet og ferdigstilt etter det ble oppdaget at filmen var en tapt tysk spillefilm, uten andre kjente kopier. I det digitale arbeidet ble den originale visningskopien (ID-X) skannet i 2022. Prosjektet hadde som mål å digitalt sikre filmen, med dens originale uttrykk. ",
+      "lang": "nor"
+    }
+  ]
+}
+```
+
+
 ### Subject
 
 | Navn         | **Subject**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Emneord knyttet til ressursen. <br> Attributt `lang` BØR brukes for å definere språkkode.   |
+| Beskrivelse  | Emneord knyttet til ressursen. <br>Attributt `authority` BØR brukes for å angi autoritet.    |
 | Krav         | KAN                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
@@ -569,12 +601,10 @@ Desimalklassifikasjon er også gyldige verdier.
 
 Det kan brukes henvisning til autoritetsregistre der det er relevant. Der det brukes autoritetsregister må emneord skrives i sin fulle form i tillegg.
 
-Språkkode bør angis (lang-attributt). [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
-
 Forklaring til bruk av *authority*-informasjon: 
-- **Source:** Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
-- **Code:** En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
-- **URI:** En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
+- `source`: Navnet på autoritetsregisteret verdien er hentet fra, oppgitt som en tekststreng.
+- `code`: En unik identifikator for autoriteten i registeret, ofte i form av en tall- eller alfanumerisk kode.
+- `URI`: En entydig lenke (URI) som peker til autoritetsoppføringen verdien er hentet fra.
 
 **Eksempler:**
 ```json
@@ -582,26 +612,23 @@ Forklaring til bruk av *authority*-informasjon:
   "subject": [
     {
       "value": "rondane",
-      "lang": "nor"
     },
     {
       "value": "fisketur",
-      "lang": "nor"
     },
     {
       "value": "natur",
-      "lang": "nor"
     }
   ]
 }
 ```
+
 
 ```json
 {
   "subject": [
     {
       "value": "natur",
-      "lang": "nor",
       "authority": {
         "source": "Kulturnav",
         "code": "1031536c-0717-4d12-8895-fb88a7d4e952",
@@ -616,13 +643,13 @@ Forklaring til bruk av *authority*-informasjon:
 
 | Navn         | **Description**                                                                                                     |
 |:--------------|:--------------------------------------------------------------------------------------------------------------------|
-| Beskrivelse  | Beskrivelse av ressursen. Beskrivelsen kan inkludere, men er ikke begrenset til: et sammendrag, en innholdsfortegnelse, en grafisk representasjon eller en fritekst om ressursen.  <br> Attributt `lang` BØR brukes for å definere språkkode.   |
+| Beskrivelse  | Beskrivelse av ressursen. Beskrivelsen kan inkludere, men er ikke begrenset til: et sammendrag, en innholdsfortegnelse, en grafisk representasjon eller en fritekst om ressursen.  <br> Attributt `lang` MÅ brukes for å definere språkkode.   |
 | Krav         | KAN                                                                                                                 |
 | Kardinalitet | 0..n                                                                                                               |
 
 **Retningslinjer for bruk:**
 
-Språkkode bør angis (lang-attributt). 
+Språkkode må angis (lang-attributt). 
 [ISO 639-3](https://www.iso.org/obp/ui/#iso:std:iso:639:-3:ed-1:v1:en) brukes som standard for å angi språk når attributt `lang` brukes.
 
 **Eksempel:**
@@ -636,9 +663,8 @@ Språkkode bør angis (lang-attributt).
   ]
 }
 ```
-<br> 
 
-**Eksempel som inneholder alle metadataelementene:**
+## Eksempel som inneholder alle metadataelementene
 
 ```json
 {


### PR DESCRIPTION
gjennomgang og oppdatering av metadatakrav. 
- små ordlydendringer og formateringsendringer.
- fjerning av `lang`-attributten på en rekke metadatafelt
